### PR TITLE
Allow building with cargo

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,22 +1,9 @@
-use std::path::*;
-use std::env;
-use std::process::Command;
-
 extern crate gcc;
 
 fn main () {
     
-    let out_dir = env::var("OUT_DIR").unwrap();
-    let base = env::current_dir().unwrap();
-    //.object
-    //.flag
     gcc::compile_library("libstart.a", &["src/arch/x86/asm.s"]);
-/*
-    gcc::Config::new()
-        .file(Path::new(&base).join("src").join("arch").join("x86").join("asm.s"))
-        .flag("-c")
-        .compile("libstart.a");
-*/
+
     //target.x86_64-unknown-linux-musl.dryad
     /*
     println!("cargo:rustc-link-search=static={}", "musldist/lib");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,8 @@
 //#![feature(no_std, lang_items, asm, core, core_str_ext)]
 //#![no_std]
+#![crate_type="dylib"]
 #![feature(asm, libc)]
-#![no_main]
+//#![no_main]
 
 //#![feature(std_panic, recover)]
 


### PR DESCRIPTION
Replaced direct calls to library methods with indirect calls via a table in .data

Inefficient, but allows building under the restrictions of cargo's build scripts
